### PR TITLE
Avoid having SyntaxWarnings

### DIFF
--- a/Python/chapter01/p06_string_compression/nickolasteixeira.py
+++ b/Python/chapter01/p06_string_compression/nickolasteixeira.py
@@ -27,10 +27,10 @@ the original string. You can assume the string has only uppercase and lowercase 
                 new_str += '1'
 
     for letter in new_str:
-        if letter is '1':
+        if letter == '1':
             new_count += 1
 
-    if len(string) // new_count is 1:
+    if len(string) // new_count == 1:
         return string
     return new_str
 

--- a/Python/chapter01/p07_rotate_matrix/nickolasteixeira.py
+++ b/Python/chapter01/p07_rotate_matrix/nickolasteixeira.py
@@ -10,7 +10,7 @@ def build_matrix(w, h, max=10):
 
 def rotate_matrix(matrix):
     '''function that rotates a matrix clockwise'''
-    if (len(matrix) is 0 or len(matrix) is not len(matrix[0])): return False
+    if (len(matrix) == 0 or len(matrix) is not len(matrix[0])): return False
     matrix_length = len(matrix)
     for layer in range(matrix_length//2):
         first = layer

--- a/Python/chapter01/p08_zero_matrix/nickolasteixeira.py
+++ b/Python/chapter01/p08_zero_matrix/nickolasteixeira.py
@@ -16,7 +16,7 @@ column are set to 0.'''
 
     for idx1 in range(len(matrix)):
         for idx2 in range(len(matrix[idx1])):
-            if matrix[idx1][idx2] is 0:
+            if matrix[idx1][idx2] == 0:
                 zero_present = True
                 row.append(idx1)
                 column.append(idx2)


### PR DESCRIPTION
Few quick fixes to avoid Python SyntaxWarnings in the output when
running `./test.sh`.